### PR TITLE
chore: bumping docker images to keep up to date

### DIFF
--- a/auth.Dockerfile
+++ b/auth.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 COPY . .
 

--- a/dns.Dockerfile
+++ b/dns.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.17.0
 
 RUN apk --no-cache add dnsmasq
 

--- a/returnhome.Dockerfile
+++ b/returnhome.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 COPY . .
 


### PR DESCRIPTION
Bumps versions to latest LTS versions for Ubuntu and more up to date version for Alpine.